### PR TITLE
Partial fix for homepage

### DIFF
--- a/src/youtube/js/features/general.js
+++ b/src/youtube/js/features/general.js
@@ -33,7 +33,7 @@ ImprovedTube.youtube_home_page = function() {
             }
 
             node.href = value;
-
+            node.outerHTML = String(node.outerHTML);
             node.addEventListener('click', function() {
                 if (
                     this.data &&
@@ -50,6 +50,7 @@ ImprovedTube.youtube_home_page = function() {
 
         for (var i = 0, l = node_list.length; i < l; i++) {
             node_list[i].href = node_list[i].getAttribute('it-origin') || '/';
+            node_list[i].outerHTML = String(node.node_list[i].outerHTML);
         }
     }
 };


### PR DESCRIPTION
This is a partial fix for the broken homepage redirect feature described in issue #567. It's a partial fix because it seems to only work on the YouTube logo, and not the sidebar. The fix works by removing all event listeners on the element, thus defaulting to the href provided by the browser.